### PR TITLE
Add Reason support

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1098,11 +1098,12 @@ symbol = "🎁 "
 The `ocaml` module shows the currently installed version of OCaml.
 The module will be shown if any of the following conditions are met:
 
-- The current directory contains a `dune` file
-- The current directory contains a `dune-project` file
-- The current directory contains a file with `.ml` extension 
-- The current directory contains a file with `.mli` extension 
-- The current directory contains a file with `.opam` extension 
+- The current directory contains a file with `.opam` extension or `_opam` directory
+- The current directory contains a `esy.lock` directory
+- The current directory contains a `dune` or `dune-project` file
+- The current directory contains a `jbuild` or `jbuild-ignore` file
+- The current directory contains a `.merlin` file
+- The current directory contains a file with `.ml`, `.mli`, `.re` or `.rei` extension
 
 ### Options
 

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -6,24 +6,26 @@ use crate::utils;
 /// Creates a module with the current OCaml version
 ///
 /// Will display the OCaml version if any of the following criteria are met:
-///     - Current directory contains a `dune` file
-///     - Current directory contains a `dune-project` file
-///     - Current directory contains a file with `.ml` extension
-///     - Current directory contains a file with `.mli` extension
-///     - Current directory contains a file with `.opam` extension
+///     - Current directory contains a file with `.opam` extension or `_opam` directory
+///     - Current directory contains a `esy.lock` directory
+///     - Current directory contains a `dune` or `dune-project` file
+///     - Current directory contains a `jbuild` or `jbuild-ignore` file
+///     - Current directory contains a `.merlin` file
+///     - Current directory contains a file with `.ml`, `.mli`, `.re` or `.rei` extension
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_ocaml_project = context
         .try_begin_scan()?
-        .set_files(&["dune", "dune-project"])
-        .set_extensions(&["ml", "mli", "opam"])
+        .set_files(&["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"])
+        .set_folders(&["_opam", "esy.lock"])
+        .set_extensions(&["opam", "ml", "mli", "re", "rei"])
         .is_match();
 
     if !is_ocaml_project {
         return None;
     }
 
-    let ocaml_version = utils::exec_cmd("ocaml", &["--version"])?.stdout;
-    let formatted_version = format_ocaml_version(&ocaml_version)?;
+    let ocaml_version = utils::exec_cmd("ocaml", &["-vnum"])?.stdout;
+    let formatted_version = format!("v{}", &ocaml_version);
 
     let mut module = context.new_module("ocaml");
     let config = OCamlConfig::try_load(module.config);
@@ -35,22 +37,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn format_ocaml_version(ocaml_version: &str) -> Option<String> {
-    let version = ocaml_version
-        // split into ["The", "OCaml", "toplevel,", "version", "4.10.0"]
-        .split_whitespace()
-        // return "4.10.0"
-        .nth(4)?;
-
-    Some(format!("v{}", version))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::format_ocaml_version;
     use crate::modules::utils::test::render_module;
     use ansi_term::Color;
-    use std::fs::File;
+    use std::fs::{self, File};
     use std::io;
 
     #[test]
@@ -58,6 +49,39 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let actual = render_module("ocaml", dir.path(), None);
         let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_opam_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.opam"))?.sync_all()?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_opam_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join("_opam"))?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_esy_lock_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join("esy.lock"))?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -77,6 +101,39 @@ mod tests {
     fn folder_with_dune_project() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("dune-project"))?.sync_all()?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_jbuild() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("jbuild"))?.sync_all()?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_jbuild_ignore() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("jbuild-ignore"))?.sync_all()?;
+
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_merlin_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(".merlin"))?.sync_all()?;
 
         let actual = render_module("ocaml", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
@@ -107,9 +164,9 @@ mod tests {
     }
 
     #[test]
-    fn folder_with_opam_file() -> io::Result<()> {
+    fn folder_with_re_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("any.opam"))?.sync_all()?;
+        File::create(dir.path().join("any.re"))?.sync_all()?;
 
         let actual = render_module("ocaml", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
@@ -118,15 +175,13 @@ mod tests {
     }
 
     #[test]
-    fn test_format_ocaml_version() {
-        assert_eq!(
-            format_ocaml_version("The OCaml toplevel, version 4.10.0"),
-            Some("v4.10.0".to_string())
-        );
+    fn folder_with_rei_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.rei"))?.sync_all()?;
 
-        assert_eq!(
-            format_ocaml_version("The OCaml toplevel, version 4.08.1"),
-            Some("v4.08.1".to_string())
-        );
+        let actual = render_module("ocaml", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        assert_eq!(expected, actual);
+        dir.close()
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,8 +63,8 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
             stdout: String::from("v12.0.0"),
             stderr: String::default(),
         }),
-        "ocaml --version" => Some(CommandOutput {
-            stdout: String::from("The OCaml toplevel, version 4.10.0"),
+        "ocaml -vnum" => Some(CommandOutput {
+            stdout: String::from("4.10.0"),
             stderr: String::default(),
         }),
         "php -r echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;" => {


### PR DESCRIPTION
Obtain OCaml version using `-vnum` flag.
Extend conditions to match projects using jbuild, esy, or merlin.